### PR TITLE
Using 1.8-style hash for backward compatability

### DIFF
--- a/lib/mintchip.rb
+++ b/lib/mintchip.rb
@@ -4,7 +4,7 @@ require 'mintchip/mintchip_message'
 require 'mintchip/value_request_message'
 
 module Mintchip
-  CURRENCY_CODES = { CAD: 1 }
+  CURRENCY_CODES = { :CAD => 1 }
 
   def self.currency_code(name)
     CURRENCY_CODES[name.to_sym] or raise InvalidCurrency


### PR DESCRIPTION
I realize that this is a Dumb Change, but I am currently stuck on 1.8 (Dreamhost hosting) and the old hash style is forward compatible.
